### PR TITLE
added infrastructure_type variable to configmap

### DIFF
--- a/chart/cp4d-deployer/templates/configmap.yaml
+++ b/chart/cp4d-deployer/templates/configmap.yaml
@@ -24,6 +24,8 @@ data:
         storage_type: ocs
         ocs_storage_label: ocs
         ocs_storage_size_gb: 500
+      infrastructure:
+        type: {{ .Values.infrastructure_type }}
 
     cp4d:
 

--- a/chart/cp4d-deployer/values.yaml
+++ b/chart/cp4d-deployer/values.yaml
@@ -6,6 +6,7 @@ deployer_namespace: cloud-pak-deployer
 instance_namespace: cpd-instance
 cluster_name: amt-cpd-dev
 cluster_ingress: "cluster_ingress"
+infrastructure_type: "detect"
 
 cpd_version: 4.5.0
 entitlement_key: "entitlement_key"

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ locals {
     instance_namespace = var.instance_namespace
     cluster_name = var.cluster_name
     cluster_ingress = var.cluster_ingress
+    infrastructure_type = var.infrastructure_type
 
     cpd_version = var.cpd_version
     entitlement_key = var.entitlement_key

--- a/variables.tf
+++ b/variables.tf
@@ -103,6 +103,12 @@ variable "cluster_ingress" {
   description = "The ingress subdomain for the cluster"
 }
 
+variable "infrastructure_type" {
+  type        = string
+  description = "The cluster infrastructure type."
+  default     = "detect"
+}
+
 variable "cpd_version" {
   type        = string
   description = "The CP4D version to deploy."


### PR DESCRIPTION
Added `infrastructure_type` variable, passed through to the configmap to allow for auto-detection or explicit declaration of the cluster type.